### PR TITLE
Feedback pages

### DIFF
--- a/components/feedback.js
+++ b/components/feedback.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Box, Heading, Text, Divider } from '@chakra-ui/react';
+import { format, parseISO } from 'date-fns';
+
+const Feedback = ({ author, text, createdAt }) => (
+  <Box borderRadius={4} maxWidth="700px" w="full">
+    <Heading size="sm" as="h3" mb={0} color="gray.900" fontWeight="medium">
+      {author}
+    </Heading>
+    <Text color="gray.500" mb={4} fontSize="xs">
+      {format(parseISO(createdAt), 'PPpp')}
+    </Text>
+    <Text color="gray.800">{text}</Text>
+    <Divider borderColor="gray.200" backgroundColor="gray.200" mt={8} mb={8} />
+  </Box>
+);
+
+export default Feedback;

--- a/components/siteTable.js
+++ b/components/siteTable.js
@@ -20,7 +20,6 @@ const SiteTable = ({ sites }) => (
       {sites.map(site => (
         <Box as="tr" key={site.url}>
           <Td fontWeight="medium">{site.name}</Td>
-          <Td>{site.url}</Td>
           <Td>
             <Link href={site.url} isExternal>
               {site.url}

--- a/components/siteTable.js
+++ b/components/siteTable.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Box, Link } from '@chakra-ui/react';
 import { parseISO, format } from 'date-fns';
+import NextLink from 'next/link';
 
 import { Table, Tr, Th, Td } from './table';
 
@@ -21,7 +22,14 @@ const SiteTable = ({ sites }) => (
           <Td fontWeight="medium">{site.name}</Td>
           <Td>{site.url}</Td>
           <Td>
-            <Link>View Feedback</Link>
+            <Link href={site.url} isExternal>
+              {site.url}
+            </Link>
+          </Td>
+          <Td>
+            <NextLink href="/p/[siteId]" as={`/p/${site.id}`} passHref>
+              <Link>View Feedback</Link>
+            </NextLink>
           </Td>
           <Td>{format(parseISO(site.createdAt), 'PPpp')}</Td>
         </Box>

--- a/lib/db-admin.js
+++ b/lib/db-admin.js
@@ -3,32 +3,40 @@ import { compareDesc, parseISO } from 'date-fns';
 import firebase from './firebase-admin';
 
 export const getAllFeedback = async siteId => {
-  // snapshot is a current state in time of the feedback
-  const snapshot = await firebase
-    .collection('feedback')
-    .where('siteId', '==', siteId)
-    .get();
+  try {
+    // snapshot is a current state in time of the feedback
+    const snapshot = await firebase
+      .collection('feedback')
+      .where('siteId', '==', siteId)
+      .get();
 
-  const feedback = [];
+    const feedback = [];
 
-  snapshot.forEach(doc => {
-    feedback.push({ id: doc.id, ...doc.data() });
-  });
+    snapshot.forEach(doc => {
+      feedback.push({ id: doc.id, ...doc.data() });
+    });
 
-  feedback.sort((a, b) =>
-    compareDesc(parseISO(a.createdAt), parseISO(b.createdAt))
-  );
+    feedback.sort((a, b) =>
+      compareDesc(parseISO(a.createdAt), parseISO(b.createdAt))
+    );
 
-  return feedback;
+    return { feedback };
+  } catch (error) {
+    return { error };
+  }
 };
 
 export const getAllSites = async () => {
-  const snapshot = await firebase.collection('sites').get();
-  const sites = [];
+  try {
+    const snapshot = await firebase.collection('sites').get();
+    const sites = [];
 
-  snapshot.forEach(doc => {
-    sites.push({ id: doc.id, ...doc.data() });
-  });
+    snapshot.forEach(doc => {
+      sites.push({ id: doc.id, ...doc.data() });
+    });
 
-  return sites;
+    return { sites };
+  } catch (error) {
+    return { error };
+  }
 };

--- a/lib/db-admin.js
+++ b/lib/db-admin.js
@@ -1,3 +1,5 @@
+import { compareDesc, parseISO } from 'date-fns';
+
 import firebase from './firebase-admin';
 
 export const getAllFeedback = async siteId => {
@@ -12,6 +14,10 @@ export const getAllFeedback = async siteId => {
   snapshot.forEach(doc => {
     feedback.push({ id: doc.id, ...doc.data() });
   });
+
+  feedback.sort((a, b) =>
+    compareDesc(parseISO(a.createdAt), parseISO(b.createdAt))
+  );
 
   return feedback;
 };

--- a/lib/db-admin.js
+++ b/lib/db-admin.js
@@ -1,0 +1,17 @@
+import firebase from './firebase-admin';
+
+export const getAllFeedback = async siteId => {
+  // snapshot is a current state in time of the feedback
+  const snapshot = await firebase
+    .collection('feedback')
+    .where('siteId', '==', siteId)
+    .get();
+
+  const feedback = [];
+
+  snapshot.forEach(doc => {
+    feedback.push({ id: doc.id, ...doc.data() });
+  });
+
+  return feedback;
+};

--- a/lib/db-admin.js
+++ b/lib/db-admin.js
@@ -15,3 +15,14 @@ export const getAllFeedback = async siteId => {
 
   return feedback;
 };
+
+export const getAllSites = async () => {
+  const snapshot = await firebase.collection('sites').get();
+  const sites = [];
+
+  snapshot.forEach(doc => {
+    sites.push({ id: doc.id, ...doc.data() });
+  });
+
+  return sites;
+};

--- a/lib/db.js
+++ b/lib/db.js
@@ -2,16 +2,16 @@ import firebase from './firebase';
 
 const firestore = firebase.firestore();
 
-export function createUser(uid, data) {
-  return firestore
+export const createUser = (uid, data) =>
+  firestore
     .collection('users')
     .doc(uid)
     .set({ uid, ...data }, { merge: true });
-}
 
-export function createSite(data) {
-  return firestore.collection('sites').add(data);
-}
+export const createSite = data => firestore.collection('sites').add(data);
+
+export const createFeedback = data =>
+  firestore.collection('feedback').add(data);
 
 /* 
 ! Info

--- a/pages/api/feedback/[siteId].js
+++ b/pages/api/feedback/[siteId].js
@@ -1,0 +1,8 @@
+import { getAllFeedback } from '@/lib/db-admin';
+
+export default async (req, res) => {
+  const { siteId } = req.query;
+  const feedback = await getAllFeedback(siteId);
+
+  res.status(200).json({ feedback });
+};

--- a/pages/api/feedback/[siteId].js
+++ b/pages/api/feedback/[siteId].js
@@ -2,7 +2,11 @@ import { getAllFeedback } from '@/lib/db-admin';
 
 export default async (req, res) => {
   const { siteId } = req.query;
-  const feedback = await getAllFeedback(siteId);
+  const { feedback, error } = await getAllFeedback(siteId);
+
+  if (error) {
+    res.status(500).json({ error });
+  }
 
   res.status(200).json({ feedback });
 };

--- a/pages/api/sites.js
+++ b/pages/api/sites.js
@@ -1,7 +1,11 @@
 import { getAllSites } from '@/lib/db-admin';
 
 export default async (_, res) => {
-  const sites = await getAllSites();
+  const { sites, error } = await getAllSites();
+
+  if (error) {
+    res.status(500).json({ error });
+  }
 
   res.status(200).json({ sites });
 };

--- a/pages/api/sites.js
+++ b/pages/api/sites.js
@@ -1,12 +1,7 @@
-import firebaseAdmin from '@/lib/firebase-admin';
+import { getAllSites } from '@/lib/db-admin';
 
 export default async (_, res) => {
-  const snapshot = await firebaseAdmin.collection('sites').get();
-  const sites = [];
-
-  snapshot.forEach(doc => {
-    sites.push({ id: doc.id, ...doc.data() });
-  });
+  const sites = await getAllSites();
 
   res.status(200).json({ sites });
 };

--- a/pages/p/[siteId].js
+++ b/pages/p/[siteId].js
@@ -1,4 +1,8 @@
+import { Box, Button, FormControl, FormLabel, Input } from '@chakra-ui/react';
+
 import { getAllFeedback, getAllSites } from '@/lib/db-admin';
+
+import Feedback from '@/components/feedback';
 
 export const getStaticProps = async context => {
   const { siteId } = context.params;
@@ -25,10 +29,28 @@ export const getStaticPaths = async () => {
   };
 };
 
-const SiteFeedback = ({ initialFeedback }) => {
-  console.log(initialFeedback);
+const SiteFeedback = ({ initialFeedback }) => (
+  <Box
+    display="flex"
+    flexDirection="column"
+    width="full"
+    maxWidth="700px"
+    margin="0 auto"
+  >
+    <Box as="form">
+      <FormControl my={8}>
+        <FormLabel htmlFor="comment">Comment</FormLabel>
+        <Input id="comment" placeholder="Leave a comment" />
+        <Button type="submit" fontWeight="medium" mt={4}>
+          Add Comment
+        </Button>
+      </FormControl>
+    </Box>
 
-  return <h1>Hi, there!!!</h1>;
-};
+    {initialFeedback.map(feedback => (
+      <Feedback key={feedback.id} {...feedback} />
+    ))}
+  </Box>
+);
 
 export default SiteFeedback;

--- a/pages/p/[siteId].js
+++ b/pages/p/[siteId].js
@@ -10,7 +10,7 @@ import Feedback from '@/components/feedback';
 
 export const getStaticProps = async context => {
   const { siteId } = context.params;
-  const feedback = await getAllFeedback(siteId);
+  const { feedback } = await getAllFeedback(siteId);
 
   return {
     props: {
@@ -20,7 +20,7 @@ export const getStaticProps = async context => {
 };
 
 export const getStaticPaths = async () => {
-  const sites = await getAllSites();
+  const { sites } = await getAllSites();
   const paths = sites.map(site => ({
     params: {
       siteId: site.id.toString(),

--- a/pages/p/[siteId].js
+++ b/pages/p/[siteId].js
@@ -1,5 +1,9 @@
+import React from 'react';
+import { useRouter } from 'next/router';
 import { Box, Button, FormControl, FormLabel, Input } from '@chakra-ui/react';
 
+import { useAuth } from '@/lib/auth';
+import { createFeedback } from '@/lib/db';
 import { getAllFeedback, getAllSites } from '@/lib/db-admin';
 
 import Feedback from '@/components/feedback';
@@ -29,28 +33,52 @@ export const getStaticPaths = async () => {
   };
 };
 
-const SiteFeedback = ({ initialFeedback }) => (
-  <Box
-    display="flex"
-    flexDirection="column"
-    width="full"
-    maxWidth="700px"
-    margin="0 auto"
-  >
-    <Box as="form">
-      <FormControl my={8}>
-        <FormLabel htmlFor="comment">Comment</FormLabel>
-        <Input id="comment" placeholder="Leave a comment" />
-        <Button type="submit" fontWeight="medium" mt={4}>
-          Add Comment
-        </Button>
-      </FormControl>
-    </Box>
+const SiteFeedback = ({ initialFeedback }) => {
+  const auth = useAuth();
+  const router = useRouter();
+  const inputEl = React.useRef(null);
+  const [allFeedback, setAllFeedback] = React.useState(initialFeedback);
 
-    {initialFeedback.map(feedback => (
-      <Feedback key={feedback.id} {...feedback} />
-    ))}
-  </Box>
-);
+  const onSubmit = e => {
+    e.preventDefault();
+
+    const newFeedback = {
+      author: auth.user.name,
+      authorId: auth.user.uid,
+      siteId: router.query.siteId,
+      text: inputEl.current.value,
+      createdAt: new Date().toISOString(),
+      provider: auth.user.provider,
+      status: 'pending',
+    };
+
+    setAllFeedback([newFeedback, ...allFeedback]);
+    createFeedback(newFeedback);
+  };
+
+  return (
+    <Box
+      display="flex"
+      flexDirection="column"
+      width="full"
+      maxWidth="700px"
+      margin="0 auto"
+    >
+      <Box as="form" onSubmit={onSubmit}>
+        <FormControl my={8}>
+          <FormLabel htmlFor="comment">Comment</FormLabel>
+          <Input ref={inputEl} id="comment" placeholder="Leave a comment" />
+          <Button type="submit" fontWeight="medium" mt={4}>
+            Add Comment
+          </Button>
+        </FormControl>
+      </Box>
+
+      {allFeedback.map(feedback => (
+        <Feedback key={feedback.id} {...feedback} />
+      ))}
+    </Box>
+  );
+};
 
 export default SiteFeedback;

--- a/pages/p/[siteId].js
+++ b/pages/p/[siteId].js
@@ -1,0 +1,34 @@
+import { getAllFeedback, getAllSites } from '@/lib/db-admin';
+
+export const getStaticProps = async context => {
+  const { siteId } = context.params;
+  const feedback = await getAllFeedback(siteId);
+
+  return {
+    props: {
+      initialFeedback: feedback,
+    },
+  };
+};
+
+export const getStaticPaths = async () => {
+  const sites = await getAllSites();
+  const paths = sites.map(site => ({
+    params: {
+      siteId: site.id.toString(),
+    },
+  }));
+
+  return {
+    paths,
+    fallback: false,
+  };
+};
+
+const SiteFeedback = ({ initialFeedback }) => {
+  console.log(initialFeedback);
+
+  return <h1>Hi, there!!!</h1>;
+};
+
+export default SiteFeedback;

--- a/pages/p/[siteId].js
+++ b/pages/p/[siteId].js
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useRef, useState } from 'react';
 import { useRouter } from 'next/router';
 import { Box, Button, FormControl, FormLabel, Input } from '@chakra-ui/react';
 
@@ -33,11 +33,11 @@ export const getStaticPaths = async () => {
   };
 };
 
-const SiteFeedback = ({ initialFeedback }) => {
+const FeedbackPage = ({ initialFeedback }) => {
   const auth = useAuth();
   const router = useRouter();
-  const inputEl = React.useRef(null);
-  const [allFeedback, setAllFeedback] = React.useState(initialFeedback);
+  const inputEl = useRef(null);
+  const [allFeedback, setAllFeedback] = useState(initialFeedback);
 
   const onSubmit = e => {
     e.preventDefault();
@@ -64,15 +64,17 @@ const SiteFeedback = ({ initialFeedback }) => {
       maxWidth="700px"
       margin="0 auto"
     >
-      <Box as="form" onSubmit={onSubmit}>
-        <FormControl my={8}>
-          <FormLabel htmlFor="comment">Comment</FormLabel>
-          <Input ref={inputEl} id="comment" placeholder="Leave a comment" />
-          <Button type="submit" fontWeight="medium" mt={4}>
-            Add Comment
-          </Button>
-        </FormControl>
-      </Box>
+      {auth.user && (
+        <Box as="form" onSubmit={onSubmit}>
+          <FormControl my={8}>
+            <FormLabel htmlFor="comment">Comment</FormLabel>
+            <Input ref={inputEl} id="comment" placeholder="Leave a comment" />
+            <Button type="submit" fontWeight="medium" mt={4}>
+              Add Comment
+            </Button>
+          </FormControl>
+        </Box>
+      )}
 
       {allFeedback.map(feedback => (
         <Feedback key={feedback.id} {...feedback} />
@@ -81,4 +83,4 @@ const SiteFeedback = ({ initialFeedback }) => {
   );
 };
 
-export default SiteFeedback;
+export default FeedbackPage;


### PR DESCRIPTION
- Fetch feedback data from Firestore
- Dynamic routing with `getStaticProps` and `getStaticPaths`
- Create individual feedback pages for each site
- Save feedback on form submit
- Use `next/link` for client-side routing